### PR TITLE
Manually maintain the "Recent News" part of the side bar.

### DIFF
--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -18,12 +18,10 @@
   </div>
 </div>
 <div class="panel panel-primary">
-  <div class="panel-heading">Latest News</div>
+  <div class="panel-heading">Recent News</div>
   <div class="panel-body">
     <ul class="nav nav-pills nav-stacked">
-      {% for post in site.posts limit:3 %}
-      <li><a href="{{ post.url }}">{{ post.title }}</a></li>
-      {% endfor %}
+      {% include recent-news.html %}
     </ul>
   </div>
 </div>

--- a/_includes/recent-news.html
+++ b/_includes/recent-news.html
@@ -1,0 +1,4 @@
+<li><a href="/news/2013/11/wxwidgets-3-0-0-released/">wxWidgets 3.0.0 Released</a></li>
+<li><a href="/news/2014/02/google-summer-of-code-2014/">Google Summer of Code 2014</a></li>
+<li><a href="/news/2014/02/new-official-website-launched/">New Website Launched</a></li>
+


### PR DESCRIPTION
Bryan: please let me know if you have any comments or see a better way of doing it. I don't like this very much (not having to duplicate the title/link would be better) but I have no idea about how to pick the news items I want otherwise, so finally this simple solution was all I could do.
