### PR TITLE
Add 3.0.4 release post and update download links.

### DIFF
--- a/_posts/2018-03-06-wxwidgets-3.0.4-released.md
+++ b/_posts/2018-03-06-wxwidgets-3.0.4-released.md
@@ -1,0 +1,34 @@
+---
+title: "wxWidgets 3.0.4 Released"
+date: 2018-03-08
+comments: true
+---
+
+wxWidgets 3.0.4, the latest release in the stable 3.0 series, is now
+[available][1]. Upgrading to it is strongly recommended for all users of the
+previous 3.0.x release as it brings a lot of bug fixes and support for newer
+compilers (MinGW 4.9, 5 and 7), SDKs (macOS 10.10 and later) and libraries
+(GStreamer 1.0) but remains 100% compatible with 3.0.0, both at the API and
+the ABI level, and so upgrading to it doesn't require absolutely any changes
+to the existing applications.
+
+The [announcement post][2] contains the fuller list of the most important
+changes in this release and they are described in even more details in the
+[change log][3].
+
+<!--more-->
+
+As usual, in addition to the sources, you can also download binaries for the
+selected Windows compilers (any version of Microsoft Visual C++ from 2008 to
+2017 or [MinGW-TDM][4] 4.9.2, 5.1.0 or 7.2.0). And you can read the documentation for
+this release [online][5].
+
+Thanks to everybody who contributed, by reporting bugs and submitting patches,
+to this wxWidgets release. We hope you will find it even better than the
+previous one and will enjoy using it!
+
+[1]: https://github.com/wxWidgets/wxWidgets/releases/tag/v3.0.4
+[2]: https://github.com/wxWidgets/wxWidgets/blob/v3.0.4/docs/publicity/announce.txt
+[3]: https://github.com/wxWidgets/wxWidgets/blob/v3.0.4/docs/changes.txt#L583-L648
+[4]: http://tdm-gcc.tdragon.net/
+[5]: http://docs.wxwidgets.org/3.0.4/

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -58,19 +58,19 @@ are available below.
 
 * Released: February 29, 2016
 
-## Latest Stable Release: 3.0.3
+## Latest Stable Release: 3.0.4
 
 <div class="row">
   <div class="col-sm-6">
     <div class="well well-small">
       <p><strong>Source Code</strong></p>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3.zip">Windows ZIP</a> (31 MB)<br>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3.7z">Windows 7Z</a> (16 MB)<br>
-      <a href="{{ page.mirror }}/v3.0.3/wxMSW-3.0.3-Setup.exe">Windows Installer</a> (47 MB)<br>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3.tar.bz2">Source for Linux, OS X, etc</a> (20 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4.zip">Windows ZIP</a> (31 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4.7z">Windows 7Z</a> (16 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxMSW-3.0.4-Setup.exe">Windows Installer</a> (47 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4.tar.bz2">Source for Linux, OS X, etc</a> (20 MB)<br>
       <p></p>
       <p><strong>Binaries</strong></p>
-      <a href="https://github.com/wxWidgets/wxWidgets/releases/tag/v3.0.3">wxMSW DLLs</a> for the selected compilers:
+      <a href="https://github.com/wxWidgets/wxWidgets/releases/tag/v3.0.4">wxMSW DLLs</a> for the selected compilers:
       <ul>
         <li>Visual C++ 2008-2017 (more details <a href="http://wxwidgets.blogspot.com/2012/08/how-to-use-294-wxmsw-binaries.html">here</a>)</li>
         <li>TDM-GCC 4.9 and 5.1</li>
@@ -82,18 +82,18 @@ are available below.
   <div class="col-sm-6">
     <div class="well well-small">
       <p><strong>Documentation</strong></p>
-      <a href="https://github.com/wxWidgets/wxWidgets/blob/v3.0.3/docs/readme.txt">Readme</a><br>
-      <a href="https://github.com/wxWidgets/wxWidgets/blob/v3.0.3/docs/changes.txt#L583-L632">Changes</a><br>
+      <a href="https://github.com/wxWidgets/wxWidgets/blob/v3.0.4/docs/readme.txt">Readme</a><br>
+      <a href="https://github.com/wxWidgets/wxWidgets/blob/v3.0.4/docs/changes.txt#L583-L632">Changes</a><br>
       <p></p>
-      <a href="http://docs.wxwidgets.org/3.0.3/">Online Manual</a><br>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3-docs-html.zip">Manual (HTML) ZIP</a> (33 MB)<br>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3-docs-html.tar.bz2">Manual (HTML) BZIP</a> (23 MB)<br>
-      <a href="{{ page.mirror }}/v3.0.3/wxWidgets-3.0.3-docs-chm.zip">Manual (CHM)</a> (32 MB)
+      <a href="http://docs.wxwidgets.org/3.0.4/">Online Manual</a><br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4-docs-html.zip">Manual (HTML) ZIP</a> (33 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4-docs-html.tar.bz2">Manual (HTML) BZIP</a> (23 MB)<br>
+      <a href="{{ page.mirror }}/v3.0.4/wxWidgets-3.0.4-docs-chm.zip">Manual (CHM)</a> (32 MB)
     </div>
   </div>
 </div>
 
-* Released: May 2nd, 2017
+* Released: March 8th, 2018
 * API Stable Since: November 11th, 2013
 
 


### PR DESCRIPTION
This is updated for 3.0.4, except as there is no google announcement post to link to yet, I linked to the repo announcement.