### PR TITLE
Show download statistics on downloads page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 # Translations Build Files
 /_cron/locale/
 /about/translations/stats.js
+
+# Download stats files
+/downloads/downloads.json

--- a/_cron/update_download_stats.rb
+++ b/_cron/update_download_stats.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+# Set WX_SITE_DIR before running this script
+# This script updates the download statistics from github
+
+require 'yaml'
+require 'json'
+require 'open-uri'
+
+wx_site_dir = ENV["WX_SITE_DIR"]
+
+# Download updated release asset information
+release_info = YAML.safe_load(File.open('%s/_data/releases.yml' % wx_site_dir))
+release_info.each do |release|
+  version = release['version']
+  asset_info_url = 'https://api.github.com/repos/wxWidgets/wxWidgets/releases/tags/v%s' % version
+
+  download = open(asset_info_url)
+  data = JSON.parse(download.read)
+
+  # Only a subset of data from github is required
+  release['assets'] = []
+  data['assets'].each do |asset|
+    release['assets'].push({
+        "id" => asset["id"],
+        "size" => asset["size"],
+        "download_count" => asset["download_count"]
+    })
+  end
+end
+
+File.open('%s/downloads/downloads.json' % wx_site_dir, 'w+') do |f| 
+  f.write(JSON.pretty_generate(release_info))
+end

--- a/downloads/downloads.js
+++ b/downloads/downloads.js
@@ -1,0 +1,38 @@
+'use strict'
+
+// Show download statistics
+$(document).ready(function () {
+    // The array wxdl_releases is initialized from the /downloads/index.md
+    // it is based on /_data/releases.yml
+
+    // Enumerate all releases
+    for (var rel_index = 0; rel_index < wxdl_releases.length; ++rel_index) {
+        // Download release info from github
+        var info_url =
+            "https://api.github.com/repos/wxWidgets/wxWidgets/releases/tags/v" +
+            wxdl_releases[rel_index].version;
+
+        $.ajax({
+            url: info_url,
+            cache: true,
+            success: function (data, text_status, xhr) {
+                // Try to find a DOM element for each element
+                for (var index = 0; index < data.assets.length; ++index) {
+                    var asset = data.assets[index];
+
+                    // Create a tooltip for each asset
+                    $('.wxdl_' + asset.id).each(function (index, elem) {
+                        $(elem).tooltip({
+                            title: Math.ceil(asset.size / 1024 / 1024) + " MiB<br>"
+                                + asset.download_count.toLocaleString() + " downloads",
+                            html: true,
+                            placement: "right"
+                        });
+                    });
+                }
+
+            }
+        });
+    }
+
+});

--- a/downloads/downloads.js
+++ b/downloads/downloads.js
@@ -2,23 +2,17 @@
 
 // Show download statistics
 $(document).ready(function () {
-    // The array wxdl_releases is initialized from the /downloads/index.md
-    // it is based on /_data/releases.yml
+    $.ajax({
+        url: "downloads.json",
+        cache: true,
+        success: function (data, text_status, xhr) {
+            // Enumerate all releases
+            for (var rel_index = 0; rel_index < data.length; ++rel_index) {
+                var rel_data = data[rel_index];
 
-    // Enumerate all releases
-    for (var rel_index = 0; rel_index < wxdl_releases.length; ++rel_index) {
-        // Download release info from github
-        var info_url =
-            "https://api.github.com/repos/wxWidgets/wxWidgets/releases/tags/v" +
-            wxdl_releases[rel_index].version;
-
-        $.ajax({
-            url: info_url,
-            cache: true,
-            success: function (data, text_status, xhr) {
                 // Try to find a DOM element for each element
-                for (var index = 0; index < data.assets.length; ++index) {
-                    var asset = data.assets[index];
+                for (var index = 0; index < rel_data.assets.length; ++index) {
+                    var asset = rel_data.assets[index];
 
                     // Create a tooltip for each asset
                     $('.wxdl_' + asset.id).each(function (index, elem) {
@@ -30,9 +24,8 @@ $(document).ready(function () {
                         });
                     });
                 }
-
             }
-        });
-    }
+        }
+    });
 
 });

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -74,11 +74,6 @@ that we can't provide binaries for all of them. On Linux, we recommend using
 the official wxGTK packages provided by each distribution, but newer packages
 are available below.
 
-<script>
-  // Provide release info to java script
-  var wxdl_releases = {{ site.data.releases | jsonify }};
-</script>
-
 {% for release in site.data.releases %}
 ## Latest {{ release.channel }} Release: {{ release.version }}
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -53,6 +53,8 @@ binaries:
     id: ReleaseDLL
   - description: "Release DLLs PDB Files"
     id: ReleasePDB
+scripts:
+  - "downloads.js"
 ---
 
 <div class="alert alert-info">
@@ -72,6 +74,10 @@ that we can't provide binaries for all of them. On Linux, we recommend using
 the official wxGTK packages provided by each distribution, but newer packages
 are available below.
 
+<script>
+  // Provide release info to java script
+  var wxdl_releases = {{ site.data.releases | jsonify }};
+</script>
 
 {% for release in site.data.releases %}
 ## Latest {{ release.channel }} Release: {{ release.version }}
@@ -95,8 +101,7 @@ are available below.
           {% assign asset_filename = archive.prefix | append: release.version | append: archive.postfix %}
           {% assign asset = release_assets | where: "name", asset_filename | first %}
           
-          <a href="{{ asset.browser_download_url }}">{{ archive.description }}</a>
-          ({{ asset.size | times: 1.0 | divided_by: 1024 | divided_by: 1024 | ceil }} MiB)
+          <a href="{{ asset.browser_download_url }}" class="wxdl_{{ asset.id }}">{{ archive.description }}</a>
           <br>
 
         {% endfor %}
@@ -135,8 +140,7 @@ are available below.
           {% assign asset_filename = "wxWidgets-" | append: release.version | append: doc.postfix %}
           {% assign asset = release_assets | where: "name", asset_filename | first %}
           
-          <a href="{{ asset.browser_download_url }}">{{ doc.description }}</a>
-          ({{ asset.size | times: 1.0 | divided_by: 1024 | divided_by: 1024 | ceil }} MiB)
+          <a href="{{ asset.browser_download_url }}" class="wxdl_{{ asset.id }}">{{ doc.description }}</a>
           <br>
         {% endfor %}
       </div>
@@ -177,8 +181,7 @@ are available below.
               <div id="collapse{{ cardID }}" class="collapse {% if forloop.first %}show{% endif %}" aria-labelledby="heading{{ cardID }}" data-parent="#accordionMSW{{ release_id}}">
                 <div class="card-body">
                   <p class="card-text">
-                      <a href="{{ header_asset.browser_download_url }}">Header Files</a>
-                      ({{ header_asset.size | times: 1.0 | divided_by: 1024 | divided_by: 1024 | ceil }} MiB)
+                      <a href="{{ header_asset.browser_download_url }}" class="wxdl_{{ header_asset.id }}">Header Files</a>
                   </p>
 
             {% for architecture in page.architectures %}
@@ -188,8 +191,7 @@ are available below.
                 {% assign asset_filename = "wxMSW-" | append: release.version | append: "_" | append: compiler.id | append: architecture.postfix | append: "_" | append: bin.id | append: ".7z" %}
                 {% assign asset = release_assets | where: "name", asset_filename | first %}
                 {% if asset %}
-                <a href="{{ asset.browser_download_url }}">{{ bin.description }}</a> 
-                ({{ asset.size | times: 1.0 | divided_by: 1024 | divided_by: 1024 | ceil }} MiB)
+                <a href="{{ asset.browser_download_url }}" class="wxdl_{{ asset.id }}">{{ bin.description }}</a> 
                 <br />
                 {% endif %}
               {% endfor %}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "css-prefix": "node node_modules/postcss-cli/bin/postcss --use autoprefixer --replace \"assets/css/*.css\" \"!assets/css/*.min.css\"",
     "css-minify": "node node_modules/clean-css-cli/bin/cleancss --level 1 --source-map --source-map-inline-sources --output assets/css/global.min.css node_modules/bootstrap/dist/css/bootstrap.min.css \"node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.css\" assets/css/global.css",
     "js": "node node_modules/npm-run-all/bin/run-s/index.js js-minify",
-    "js-minify": "node node_modules/uglify-js/bin/uglifyjs --compress --mangle --comments \"/^!/\" --source-map \"includeSources,url=global.min.js.map\" --output assets/js/global.min.js node_modules/jquery/dist/jquery.min.js node_modules/bootstrap/dist/js/bootstrap.min.js \"node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.js\" _assets/js/*.js",
+    "js-minify": "node node_modules/uglify-js/bin/uglifyjs --compress --mangle --comments \"/^!/\" --source-map \"includeSources,url=global.min.js.map\" --output assets/js/global.min.js node_modules/jquery/dist/jquery.min.js node_modules/popper.js/dist/umd/popper.js node_modules/bootstrap/dist/js/bootstrap.min.js \"node_modules/@fancyapps/fancybox/dist/jquery.fancybox.min.js\" _assets/js/*.js",
     "dist": "node node_modules/npm-run-all/bin/run-p/index.js css js"
   },
   "browserslist": [


### PR DESCRIPTION
This shows the download counts and file size in a tooltip. The download statistic is always up to date directly from github via javascript.

![image](https://user-images.githubusercontent.com/5075894/50020128-4c6b0880-ffd5-11e8-9ea8-ea1ecbd06385.png)
