### PR TITLE
Moved navigation and partial aside content from page layout to yml data.

### DIFF
--- a/_data/aside.yml
+++ b/_data/aside.yml
@@ -1,0 +1,44 @@
+cards:
+    - title: Quick Links
+      links:
+        - title: Hello World in wxWidgets
+          url: http://docs.wxwidgets.org/trunk/overview_helloworld.html
+          icon_type: star
+          icon_category: fas
+
+        - title: Online Manual
+          url: http://docs.wxwidgets.org/3.0/
+          icon_type: book
+          icon_category: fas
+
+        - title: Community Wiki
+          url: https://wiki.wxwidgets.org/
+          icon_type: info
+          icon_category: fas
+
+        - title: Report a Bug
+          url: https://trac.wxwidgets.org/newticket
+          icon_type: bug
+          icon_category: fas
+
+        - title: GitHub Repository
+          url: https://github.com/wxWidgets/wxWidgets
+          icon_type: github
+          icon_category: fab
+
+        - title: Development Roadmap
+          url: https://trac.wxwidgets.org/wiki/Roadmap
+          icon_type: forward
+          icon_category: fas
+
+    - title: Follow Us
+      links:
+        - title: News RSS Feed
+          url: /atom.xml
+          icon_type: rss
+          icon_category: fas
+
+        - title: Developer Blog
+          url: /blog/
+          icon_type: pencil-alt
+          icon_category: fas

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,87 @@
+toc:
+    - title: Home
+      type: normal
+      url: /
+
+    - title: About
+      type: dropdown
+      pages:
+        - title: Overview
+          url: /about/
+
+        - title: Screenshots
+          url: /about/screenshots/
+
+        - title: Translations
+          url: /about/translations/
+
+        - title: The Team
+          url: /about/team/
+
+        - title: License
+          url: /about/licence/
+
+        - title: Credits
+          url: /about/credits/
+
+    - title: Downloads
+      type: normal
+      url: /downloads/
+
+    - title: Documentation
+      type: dropdown
+      pages:
+        - title: The Book
+          url: /docs/book/
+
+        - title: Reference Manuals
+          url: /docs/
+
+        - title: Frequently Asked Questions
+          url: /docs/faq/
+
+        - title: Community Wiki
+          url: https://wiki.wxwidgets.org/
+
+        - title: Tutorials
+          url: /docs/tutorials/
+
+    - title: Support
+      type: dropdown
+      pages:
+        - title: Issue Tracker
+          url: https://trac.wxwidgets.org/
+
+        -
+
+        - title: Mailing Lists
+          url: /support/mailing-lists/
+
+        - title: Forums
+          url: https://forums.wxwidgets.org/
+
+        - title: IRC Channel
+          url: /support/irc/
+
+        -
+
+        - title: Commercial Support
+          url: /support/commercial/
+
+    - title: Developers
+      type: dropdown
+      pages:
+        - title: Resources
+          url: /develop/
+
+        - title: Code Repository
+          url: /develop/code-repository/
+
+        - title: Coding Guidelines
+          url: /develop/coding-guidelines/
+
+        - title: Developer Blog
+          url: /blog/
+
+        - title: Summer of Code
+          url: /gsoc/

--- a/_includes/aside.html
+++ b/_includes/aside.html
@@ -1,42 +1,18 @@
+{% for card in site.data.aside.cards %}
 <div class="card border-primary mb-4">
-  <div class="card-header bg-primary text-light">Quick Links</div>
+  <div class="card-header bg-primary text-light">{{ card.title }}</div>
   <div class="card-body">
     <ul class="nav nav-pills flex-column">
-      <li class="nav-item"><a class="nav-link" href="https://docs.wxwidgets.org/trunk/overview_helloworld.html">
-        <i class="fas fa-star fa-fw"></i> Hello World in wxWidgets</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://docs.wxwidgets.org/3.0/">
-        <i class="fas fa-book fa-fw"></i> Online Manual</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://wiki.wxwidgets.org/">
-        <i class="fas fa-info fa-fw"></i> Community Wiki</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://trac.wxwidgets.org/newticket">
-        <i class="fas fa-bug fa-fw"></i> Report a Bug</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://github.com/wxWidgets/wxWidgets">
-        <i class="fab fa-github fa-fw"></i> GitHub Repository</a></li>
-      <li class="nav-item"><a class="nav-link" href="https://trac.wxwidgets.org/wiki/Roadmap">
-        <i class="fas fa-forward fa-fw"></i> Development Roadmap</a></li>
+    {% for item in card.links %}
+      <li class="nav-item"><a class="nav-link" href="{{ item.url }}" title="{{ item.title }}">
+        <i class="{{ item.icon_category }} fa-{{ item.icon_type }} fa-fw"></i> {{ item.title }}</a></li>
+    {% endfor %}
     </ul>
   </div>
 </div>
+{% endfor %}
 
 <div class="card border-primary mb-4 logos" style="display: none;">
   <div class="card-header bg-primary text-light">Solutions</div>
   <div class="card-body text-center"></div>
-</div>
-
-<div class="card border-primary mb-4">
-  <div class="card-header bg-primary text-light">Follow Us</div>
-  <div class="card-body">
-    <ul class="nav nav-pills flex-column">
-      <li class="nav-item">
-        <a class="nav-link" href="/atom.xml" title="News RSS Feed">
-          <i class="fas fa-rss fa-fw"></i> News RSS Feed
-        </a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/blog/" title="Developer Blog">
-          <i class="fas fa-pencil-alt fa-fw"></i> Developer Blog
-        </a>
-      </li>
-    </ul>
-  </div>
 </div>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,51 +5,25 @@
 </div>
 <div class="collapse navbar-collapse" id="navbarSupportedContent">
   <ul class="navbar-nav mr-auto">
-    <li class="nav-item"><a class="nav-link" href="/">Home</a></li>
+{% for item in site.data.navigation.toc %}
+  {% if item.type == 'normal' %}
+    <li class="nav-item"><a class="nav-link" href="{{ item.url }}">{{ item.title }}</a>
+  {% else %}
+    {% assign item_id = 'navbar' | append: item.title %}
     <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkAbout" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">About</a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkAbout">
-        <a class="dropdown-item" href="/about/">Overview</a>
-        <a class="dropdown-item" href="/about/screenshots/">Screenshots</a>
-        <a class="dropdown-item" href="/about/translations/">Translations</a>
-        <a class="dropdown-item" href="/about/team/">The Team</a>
-        <a class="dropdown-item" href="/about/licence/">License</a>
-        <a class="dropdown-item" href="/about/credits/">Credits</a>
-      </div>
-    </li>
-    <li class="nav-item"><a class="nav-link" href="/downloads/">Downloads</a></li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkDocumentation" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Documentation</a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkDocumentation">
-        <a class="dropdown-item" href="/docs/book/">The Book</a>
-        <a class="dropdown-item" href="/docs/">Reference Manuals</a>
-        <a class="dropdown-item" href="/docs/faq/">Frequently Asked Questions</a>
-        <a class="dropdown-item" href="https://wiki.wxwidgets.org/" target="_blank">Community Wiki</a>
-        <a class="dropdown-item" href="/docs/tutorials/">Tutorials</a>
-      </div>
-    </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkSupport" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Support</a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkSupport">
-        <a class="dropdown-item" href="https://trac.wxwidgets.org/" target="_blank">Issue Tracker</a>
+      <a class="nav-link dropdown-toggle" href="#" id="{{ item_id }}" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ item.title }}</a>
+      <div class="dropdown-menu" aria-labelledby="{{ item_id }}">
+    {% for pag in item.pages %}
+      {% if pag.title == nil %}
         <div class="dropdown-divider"></div>
-        <a class="dropdown-item" href="/support/mailing-lists/">Mailing Lists</a>
-        <a class="dropdown-item" href="https://forums.wxwidgets.org/" target="_blank">Forums</a>
-        <a class="dropdown-item" href="/support/irc/">IRC Channel</a>
-        <div class="dropdown-divider"></div>
-        <a class="dropdown-item" href="/support/commercial/">Commercial Support</a>
+      {% else %}
+        <a class="dropdown-item" href="{{ pag.url }}">{{ pag.title }}</a>
+      {% endif %}
+    {% endfor %}
       </div>
+  {% endif %}
     </li>
-    <li class="nav-item dropdown">
-      <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLinkDevelopers" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Developers</a>
-      <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkDevelopers">
-        <a class="dropdown-item" href="/develop/">Resources</a>
-        <a class="dropdown-item" href="/develop/code-repository/">Code Repository</a>
-        <a class="dropdown-item" href="/develop/coding-guidelines/">Coding Guidelines</a>
-        <a class="dropdown-item" href="/blog/">Developer Blog</a>
-        <a class="dropdown-item" href="/gsoc/">Summer of Code</a>
-      </div>
-    </li>
+{% endfor %}
   </ul>
   <form class="form-inline" role="search" action="/search/">
     <input class="form-control mr-sm-2" type="search" name="q" placeholder="Search" aria-label="Search">


### PR DESCRIPTION
Added some separation between pages content and pages layout by adding 2 yml files in _data directory for both navigation and aside, loading them into related pages using liquid.
There is no visible changes except for the aside where the 'Solutions' card was moved below due some needed complexity to add in the aside.html include and so make the separation completed in that page.