### PR TITLE
Update name of install instructions file in MSW FAQ

### DIFF
--- a/docs/faq/windows/index.md
+++ b/docs/faq/windows/index.md
@@ -46,7 +46,7 @@ themed automatically so long as you include wx.rc in your own .rc file.
 
 ### What compilers are supported?
 
-Please see docs/msw/install.txt file for up-to-date information.
+Please see [docs/msw/install.md](https://github.com/wxWidgets/wxWidgets/blob/master/docs/msw/install.md) file for up-to-date information.
 Also see [this article](https://docs.wxwidgets.org/trunk/page_introduction.html#page_introduction_requirements).
 
 <a name="bestcompiler"></a>


### PR DESCRIPTION
TBH, I believe there is a lot of information in the FAQs that in time became outdated or having little relevance.

E.g., in the MSW part it would be information about DBCS, reducing executable size, best compilers, DLLs...  I did not dare to make bold changes attempting to correct this.

And while this may be just a matter of personal preference, some parts of the FAQs read like opinions and not technical writing which I would rather avoid.

