### PR TITLE
Remove wx-translators from available mailing lists

### DIFF
--- a/about/translations/index.md
+++ b/about/translations/index.md
@@ -68,15 +68,11 @@ wxWidgets translations. Here are the steps you should follow:
 * Send the finished translation to [Vadim Zeitlin][5] and it will be added to
   the next wxWidgets release or snapshot.
 
-In addition, please consider subscribing to the [translators mailing list][6]
-where special announcements for translators are announced.
-
 [1]: https://raw.githubusercontent.com/wxWidgets/wxWidgets/master/locale/wxstd.pot
 [2]: http://www.loc.gov/standards/iso639-2/php/English_list.php
 [3]: http://www.iso.org/iso/prods-services/iso3166ma/02iso-3166-code-lists/country_names_and_code_elements
 [4]: http://www.poedit.net/
 [5]: mailto:vadim@wxwidgets.org
-[6]: /support/mailing-lists/
 
 ## Translators
 

--- a/support/mailing-lists/index.md
+++ b/support/mailing-lists/index.md
@@ -70,17 +70,6 @@ list are moderated.
 
 [wx-announce-group]: https://groups.google.com/forum/?fromgroups#!forum/wx-announce
 
-### Translators List
-
-For anyone involved in writing translations for wxWidgets.
-
-* To Post: <wx-translators@googlegroups.com>
-* Subscribe: <wx-translators+subscribe@googlegroups.com>
-* Unsubscribe: <wx-translators+unsubscribe@googlegroups.com>
-* Archives: [Google Group][wx-translators-group]
-
-[wx-translators-group]: https://groups.google.com/forum/?fromgroups#!forum/wx-translators
-
 ### Source Code Updates List
 
 This list is for the convenience of any developers that wish to recieve


### PR DESCRIPTION
I believe that the translators mailing list has been of no real use for many years, linking to a list overtaken by Chinese spammers may not look that good; therefore its references should be removed from the website. However, I would understand if you feel different.

**Off-Topic 1:** When I type just `www.wxwidgets.org` in my browser, the site opens with the http protocol. Additionally, `http://www.wxwidgets.org` is not redirected to `https://www.wxwidgets.org`. Is this by design?

**Off-Topic 2:** Is Buildbot still being used? The first two related links in _Continous Integration_ at https://www.wxwidgets.org/develop/ are invalid.

**Off-Topic 3:**  The second sentence on the main page refers to wxRuby at RubyForge. RubyForge seems to have shut down in 2014. I found https://rubygems.org/gems/wxruby but that was last updated in 2009...