### PR TITLE
Add anchors to the download page

### DIFF
--- a/downloads/downloads.js
+++ b/downloads/downloads.js
@@ -28,4 +28,13 @@ $(document).ready(function () {
         }
     });
 
+    // Look for hash in URL and open MSW binaries model if available
+    if (document.location.hash) {
+        var data = /^#v(.\..\..)_msw$/.exec(document.location.hash);
+
+        if (data && data.length > 1) {
+            var id = data[1].replace(/\./g, '');
+            $('#mswModal' + id).modal('show');
+        }
+    }
 });

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -74,6 +74,7 @@ are available below.
 
 {% for release in site.data.releases %}
 <a name="v{{ release.version }}"></a>
+<a name="v{{ release.version }}_msw"></a>
 <a name="{{ release.channel | downcase }}"></a>
 ## Latest {{ release.channel }} Release: {{ release.version }}
 

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -73,6 +73,8 @@ the official wxGTK packages provided by each distribution, but newer packages
 are available below.
 
 {% for release in site.data.releases %}
+<a name="v{{ release.version }}"></a>
+<a name="{{ release.channel | downcase }}"></a>
 ## Latest {{ release.channel }} Release: {{ release.version }}
 
 <p class="text-muted mb-0">Released: {{ release.released }}</p>
@@ -209,6 +211,7 @@ are available below.
 
 {% endfor %}
 
+<a name="v2.8.12"></a>
 ## Previous Stable Release: 2.8.12
 
 <p class="text-muted mb-0">Released: March 28th, 2011</p>


### PR DESCRIPTION
This allows directly linking to a specic release.
Either using a specic version like:
https://www.wxwidgets.org/downloads#v3.1.3
Or a release channel like this:
https://www.wxwidgets.org/downloads#stable
Or development like this:
https://www.wxwidgets.org/downloads#development

Additionally:
https://www.wxwidgets.org/downloads#v3.1.3_msw
will jump to the same location as #v3.1.3
but the javascript will detect the suffix and will open the popup
with the MSW binaries. (This will only work with a specific version not with stable/development)