### PR TITLE
wxWidgets 3.0.5 release notice

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,9 +3,9 @@
   released: October 28, 2019
   bin_url_debian: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets31Binaries#toc2
   bin_url_fedora: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets31Binaries#toc3
-- version: 3.0.4
+- version: 3.0.5
   channel: Stable
-  released: March 8th, 2018
+  released: April 27th, 2020
   stable_api_since: November 11th, 2013
   bin_url_debian: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc2
   bin_url_fedora: https://wiki.codelite.org/pmwiki.php/Main/WxWidgets30Binaries#toc3

--- a/_posts/2020-04-25-wxwidgets-3.0.5-released.md
+++ b/_posts/2020-04-25-wxwidgets-3.0.5-released.md
@@ -1,0 +1,35 @@
+---
+title: "wxWidgets 3.0.5 Released"
+date: 2020-04-25
+comments: true
+---
+
+wxWidgets 3.0.5, the latest release in the stable 3.0 series, is now
+[available][1]. Upgrading to it is strongly recommended for all users of the
+previous 3.0.x release as it brings a lot of bug fixes and support for newer
+compilers (MinGW 4.9, 5 and 7), SDKs (macOS 10.10 and later) and libraries
+(GStreamer 1.0) but remains 100% compatible with 3.0.0, both at the API and
+the ABI level, and so upgrading to it doesn't require absolutely any changes
+to the existing applications.
+
+The [announcement post][2] contains the fuller list of the most important
+changes in this release and they are described in even more details in the
+[change log][3].
+
+<!--more-->
+
+As usual, in addition to the sources, you can also download binaries for the
+selected Windows compilers (any version of Microsoft Visual C++ from 2008 to
+2019, [MinGW-TDM][4] 4.9.2, 5.1.0 and 9.2.0, or [MinGW][6] 7.2.0, 7.3.0 and 8.1.0). And you can read the documentation for
+this release [online][5].
+
+Thanks to everybody who contributed, by reporting bugs and submitting patches,
+to this wxWidgets release. We hope you will find it even better than the
+previous one and will enjoy using it!
+
+[1]: https://github.com/wxWidgets/wxWidgets/releases/tag/v3.0.5
+[2]: https://github.com/wxWidgets/wxWidgets/blob/v3.0.5/docs/publicity/announce.txt
+[3]: https://github.com/wxWidgets/wxWidgets/blob/v3.0.5/docs/changes.txt#L583-L648
+[4]: http://tdm-gcc.tdragon.net/
+[5]: https://docs.wxwidgets.org/3.0.5/
+[6]: https://sourceforge.net/projects/mingw-w64/


### PR DESCRIPTION
This should be applied after the release is made.

There are other changes required but I am not sure how to do them. In addition to 3.0.5 being the latest stable, there are new compilers: VS 2017 and 2019, MinGW-9.2.0TDM.