### PR TITLE
Small tweak for compiler list on downloads page

### DIFF
--- a/downloads/index.md
+++ b/downloads/index.md
@@ -38,6 +38,12 @@ compilers:
     id: vc110
   - description: "Visual Studio 2013"
     id: vc120
+  - description: "Visual Studio 2015"
+    id: vc140
+  - description: "Visual Studio 2017"
+    id: vc141
+  - description: "Visual Studio 2019"
+    id: vc142
   - description: "Visual Studio 2015/2017/2019"
     id: vc14x
 architectures:

--- a/downloads/index.md
+++ b/downloads/index.md
@@ -159,6 +159,7 @@ are available below.
         {% assign header_asset = release_assets | where: "name", asset_filename | first %}
 
 <div class="accordion" id="accordionMSW{{ release_id }}">
+        {% assign first_available_compiler = true %}
         {% for compiler in page.compilers reversed %}
           {% assign asset_filename = "wxMSW-" | append: release.version | append: "_" | append: compiler.id | append: "_Dev.7z" %}
           {% assign dev_asset = release_assets | where: "name", asset_filename | first %}
@@ -174,7 +175,7 @@ are available below.
                 </h5>
               </div>
 
-              <div id="collapse{{ cardID }}" class="collapse {% if forloop.first %}show{% endif %}" aria-labelledby="heading{{ cardID }}" data-parent="#accordionMSW{{ release_id}}">
+              <div id="collapse{{ cardID }}" class="collapse {% if first_available_compiler %}show{% endif %}" aria-labelledby="heading{{ cardID }}" data-parent="#accordionMSW{{ release_id}}">
                 <div class="card-body">
                   <p class="card-text">
                       <a href="{{ header_asset.browser_download_url }}" class="wxdl_{{ header_asset.id }}">Header Files</a>
@@ -198,6 +199,11 @@ are available below.
               </div>
 
             </div>
+
+            {% if first_available_compiler %}
+            {% assign first_available_compiler = false %}
+            {% endif %}
+
           {% endif %}
         {% endfor %}
 </div>


### PR DESCRIPTION
* Always expand the first available msw binary
* Add explicit compiler ids for VC 2015/2015/2019