### PR TITLE
Update faqs

### DIFF
--- a/docs/faq/common/index.md
+++ b/docs/faq/common/index.md
@@ -54,8 +54,8 @@ MyFrame::MyFrame() : wxFrame(NULL, wxID_ANY, "My Frame")
 ```
 
 will appear much bigger than its specified size of `80` by `30` pixels. In
-fact, it will fill in the entire frame area, irrespectively of how big it is.
-This happens because top level windows such as `wxFrame` resize their _uniqie_
+fact, it will fill in the entire frame client area, irrespectively of how big it is.
+This happens because top level windows such as `wxFrame` resize their _unique_
 child to always fill all the available space by default and this is done so
 that the usual approach of creating a `wxPanel` inside the frame and then
 creating various controls inside this panel. Which also provides the best
@@ -82,8 +82,7 @@ different screens, using different resolutions. Please use sizers (see
 ### How to create and use custom events?
 
 Please look at the `event` wxWidgets sample source code, it shows how to do
-this among other things. Note that the way custom events are defined has
-changed in wxWidgets 2.3.1 as compared to the previous releases.
+this among other things.
 
 <a name="guithread"></a>
 
@@ -99,10 +98,9 @@ main thread asking it to do whatever is necessary.
 
 ### How can I set the TAB order of the controls?
 
-Starting from wxWidgets 2.8 you can call wxWindow::MoveBeforeInTabOrder() and
-MoveAfterInTabOrder() to change the position of a child window in the TAB
-chain. Notice that by default the TAB order is the same as the order of
-creation.
+You can call `wxWindow` methods `MoveBeforeInTabOrder()` and `MoveAfterInTabOrder()`
+to change the position of a child window in the TAB chain. Notice that
+by default the TAB order is the same as the order of creation.
 
 <a name="wxtmacro"></a>
 
@@ -141,11 +139,11 @@ Pressing `Esc` will close the dialog if and only if it has a button with
 
 ### How can I get rid of message boxes with error messages?
 
-These message boxes are probably due to calls to `wxLogError()` or other log
+These message boxes are probably shown due to calls to `wxLogError()` or other log
 functions from wxWidgets code. To completely suppress them you may use
-wxLogNull class, please see the manual for details. Do note, however, that a
+`wxLogNull` class, please see the manual for details. Do note, however, that a
 better solution is to avoid the error in the first place as suppressing these
-error message might hide other, important, ones.
+error messages might hide other, important, ones.
 
 <a name="makefile"></a>
 
@@ -165,8 +163,8 @@ program.
 
 ### XRC can't display non-ASCII characters correctly
 
-If you use the wxXRC_USE_LOCALE flag (which is on by default), strings from XRC
-files are translated using wxLocale. wxLocale assumes the strings are in ASCII
-- if the are not, wxXmlResource leaves them in UTF-8 encoding in ANSI builds of
+If you use the `wxXRC_USE_LOCALE` flag (which is on by default), strings from XRC
+files are translated using wxLocale. wxLocale assumes the strings are in ASCII -
+if they are not, `wxXmlResource` leaves them in UTF-8 encoding in ANSI builds of
 wxWidgets. Either don't use `wxXRC_USE_LOCALE` or use `translate="0"` attribute
 in XRC files.

--- a/docs/faq/general/index.md
+++ b/docs/faq/general/index.md
@@ -19,8 +19,6 @@ See also [top-level FAQ page](/docs/faq/).
 *   [How is wxWidgets distributed?](#distrib)
 *   [What is wxBase?](#base)
 *   [What is wxUniversal?](#univ)
-*   [What about Java?](#java)
-*   [What about .NET/Mono?](#dotnet)
 *   [How can I help the project?](#help)
 *   [How do I start a new port?](#newport)
 
@@ -63,7 +61,9 @@ academic or commercial developer.
 No official support, but the mailing list is very helpful and some people say
 that wxWidgets support is better than for much commercial software. The
 developers are keen to fix bugs as soon as possible, though obviously there are
-no guarantees.
+no guarantees. There is also also an active [user forum](https://forums.wxwidgets.org/)
+where wxWidgets users can get their questions answered and issues helped with by
+other wxWidgets users.
 
 <a name="users"></a>
 
@@ -86,30 +86,23 @@ Please see the [overview page](/about/) for the list of supported platforms.
 
 ### How does wxWidgets support platform-specific features?
 
-This is a hotly-debated topic amongst the developers. My own philosophy is to
-make wxWidgets as platform-independent as possible, but allow in a few classes
-(functions, window styles) that are platform-specific.
-For example, Windows metafiles and file system volumes/drives have their own
-classes on Windows, but nowhere else. Because these classes are provided and
-are wxWidgets-compatible, it doesn't take much coding effort for an application
-programmer to add support for some functionality that the user on a particular
-platform might otherwise miss. Also, some classes that started off as
-platform-specific, such as the MDI classes, have been emulated on other
-platforms. wxTaskBarIcon started as Windows-only but was eventually implemented
+wxWidgets philosophy is to make wxWidgets as platform-independent as possible,
+but allow in a few classes (functions, window styles) that are platform-specific.
+For example, Windows metafiles have their own classes on Windows, but nowhere else.
+Because these classes are provided and are wxWidgets-compatible, it doesn't take
+much coding effort for an application programmer to add support for some functionality
+that the user on a particular platform might otherwise miss. Also, some classes that
+started off as platform-specific, such as the MDI classes, have been emulated on other
+platforms. `wxTaskBarIcon` started as Windows-only but was eventually implemented
 for other ports too.
 
 In other words, wxWidgets is not a 'lowest common denominator' approach, but it
-will still be possible to write portable programs using the core API.
-Forbidding some platform-specific classes would be a stupid approach that would
-alienate many potential users, and encourage the perception that toolkits such
-as wxWidgets are not up to the demands of today's sophisticated applications.
-
-Currently resources such as bitmaps and icons are handled in a platform-
-specific way, but it is hoped to reduce this dependence in due course.
-
+is still be possible to write portable programs using the core API.
+Forbidding some platform-specific classes would be an incorrect approach that would
+alienate many potential users.
 Another reason why wxWidgets is not a 'lowest common denominator' toolkit is
 that some functionality missing on some platform has been provided using
-generic, platform-independent code, such as the wxTreeCtrl and wxListCtrl
+generic, platform-independent code, such as the `wxTreeCtrl` and `wxListCtrl`
 classes.
 
 <a name="stl"></a>
@@ -136,7 +129,7 @@ interoperability even further.
 
 These are the possibilities so far:
 
-* See [www.scintilla.org](http://www.scintilla.org) for a very nice
+* See [www.scintilla.org](https://www.scintilla.org) for a very nice
   syntax-highlighting editor widget. wxWidgets includes an implementation of
   this control named [wxStyledTextCtrl](https://docs.wxwidgets.org/stable/classwx_styled_text_ctrl.html).
 * If you only need to display marked-up information, rather than edit it, then
@@ -144,7 +137,8 @@ These are the possibilities so far:
   reference manual for details, and samples/html.
 * There is also [wxRichTextCtrl](https://docs.wxwidgets.org/stable/classwx_rich_text_ctrl.html),
   a generic control implemented on all platforms.
-* The wxTextCtrl class supports some less powerful control over styles using
+* The [wxTextCtrl](https://docs.wxwidgets.org/stable/classwx_text_ctrl.html) class supports 
+  some less powerful control over styles using
   [wxTextAttr](https://docs.wxwidgets.org/stable/classwx_text_attr.html).
 * And finally, a heavier solution is available by pulling in a full native
   browser engine using [wxWebView](https://docs.wxwidgets.org/stable/classwx_web_view.html).
@@ -181,7 +175,7 @@ We are using [git](/develop/code-repository/) to develop and maintain wxWidgets.
 This allows us to make alterations and publish them where others can update
 their source.
 
-To build source from git, see the BuildGit.txt file in the top-level wxWidgets
+To build source from git, see the README-GIT.md file in the top-level wxWidgets
 distribution directory.
 
 <a name="distrib"></a>
@@ -197,8 +191,8 @@ feeling adventurous, you may also check out the sources directly from the
 ### What is wxBase?
 
 wxBase is a subset of wxWidgets comprised by the non-GUI classes. It includes
-wxWidgets container and primitive data type classes (including wxString,
-wxDateTime and so on) and also useful wrappers for the operating system objects
+wxWidgets container and primitive data type classes (including `wxString`,
+`wxDateTime` and so on) and also useful wrappers for the operating system objects
 such as files, processes, threads, sockets and so on. With very minor
 exceptions wxBase may be used in exactly the same way as wxWidgets but it
 doesn't require a GUI to run and so is ideal for creating console mode
@@ -217,54 +211,6 @@ flexibility (for example, support for themes even under MS Windows). It also
 means that it is now much easier to port wxWidgets to a new platform as only
 the low-level classes must be ported which make for a small part of the
 library.
-
-<a name="java"></a>
-
-### What about Java?
-
-The Java honeymoon period is over :-) and people are realising that it cannot
-meet all their cross-platform development needs. We don't anticipate a major
-threat from Java, and the level of interest in wxWidgets is as high as ever.
-
-<a name="dotnet"></a>
-
-### What about .NET/Mono?
-
-Microsoft is spending a lot on promoting the .NET initiative, which is a set of
-languages, APIs and web service components for Windows. Ximian has started an
-open source version of .NET, mostly for Linux. C# is Microsoft's alternative to
-Java, supporting 'managed code', garbage collection and various other Java-like
-language features.
-
-Although this may be attractive to some developers, there is a variety of
-reasons why the .NET/Mono combination is unlikely to make wxWidgets redundant.
-Please note that the following comments are Julian Smart's opinions.
-
-1.  Not everyone wants or needs net services.
-2.  Mono Forms may only target Winelib (at least to begin with), so the end
-      result is not as native as wxWidgets (I'm aware there is GTK# for use
-      with the C# language).
-3.  C# is usually byte-compiled and therefore slower. Plus, .NET adds a
-      layer of overhead to the client computer that wxWidgets does not
-      require.
-4.  Mono hasn't proven its long-term viability yet (it's a complex system of
-      components); wxWidgets is ready now.
-5.  You may not wish to buy into Microsoft marketing spin and APIs.
-6.  Microsoft may at some point sue developers of non-Microsoft .NET
-      implementations. After all, platform-independence is not in Microsoft's
-      interest.
-7.  .NET might never be implemented on some platforms, especially Mac and
-      embedded variants of Linux.
-8.  wxPython and other language variants provide further reasons for
-      wxWidgets to continue.
-9.  The same issue exists for Qt: if Qt sales remain strong, it's a good
-      indication that the market for a C++ based approach is still there.
-      (Either that, or everyone's turning to wxWidgets!)
-
-There is nothing to stop folk from developing a C# version of the wxWidgets
-API. We already have bindings to Python, Perl, JavaScript, Lua, Basic, and
-Eiffel. Update: A [wx.NET](http://wxnet.sourceforge.net/) project is now in
-progress.
 
 <a name="help"></a>
 
@@ -299,18 +245,17 @@ files such as wx/defs.h, wx/wxchar.h for areas where you'll need to add to
 existing conditionals to set up wide character support and other issues. If the
 GUI runs on a Unix variant, define the `__UNIX__` variable in your makefile.
 
-Then you can start implementing the port, starting with wxWindow,
-wxTopLevelWindow, wxFrame, wxDialog so you can get the minimal sample running
+Then you can start implementing the port, starting with `wxWindow`,
+`wxTopLevelWindow`, `wxFrame`, `wxDialog `so you can get the minimal sample running
 as soon as possible.
 
-If GDI objects (wxPen, wxBrush, etc.) are not concepts in your native GUI, you
+If GDI objects (`wxPen`, `wxBrush`, etc.) are not concepts in your native GUI, you
 may wish to use very generic versions of some of these - see the wxX11 port.
 
 Consider using the wxUniversal widget set as a quick way to implement wxWidgets
 on your platform. You only need to define some basic classes such as device
 contexts, wxWindow, wxTopLevelWindow, GDI objects etc. and the actual widgets
-will be drawn for you. See wxX11, wxMGL, and wxMSW/Univ for sample wxUniversal
-ports.
+will be drawn for you. See wxX11 for a sample wxUniversal port.
 
 To begin with, you can use whatever makefiles or project files work for you.
 Look at existing makefiles to see what generic/common/Unix files need to be
@@ -318,9 +263,9 @@ included. Later, you'll want to integrate support for your port into configure
 (Unix-like systems and gcc under Windows), and bakefile (for other makefiles on
 Windows).
 
-Submit your port as patches via SourceForge; you might wish to separate it into
-one patch that touches common headers and source files, and another containing
+Submit your port as pull requests via GitHub; you might wish to separate it into
+one pull request that touches common headers and source files, and another containing
 the port-specific code, to make it much easier for us to review and apply the
-patches.
+changes.
 
 Good luck!

--- a/docs/faq/general/index.md
+++ b/docs/faq/general/index.md
@@ -38,9 +38,9 @@ Software's [DialogBlocks](http://www.anthemion.co.uk/dialogblocks/) is one
 commercial example, but there are many others, see the wiki
 [tools](https://wiki.wxwidgets.org/Tools) page for some of them.
 
-You don't have to use C++ to use wxWidgets: there is a
-[Python interface](http://wxpython.org/) for wxWidgets, and also a
-[Perl interface](http://wxperl.sourceforge.net/).
+You don't have to use C++ to use wxWidgets: for example there is a
+[Python interface](https://wxpython.org/), a [Lua interface](https://github.com/pkulchenko/wxlua),
+and also an [Erlang interface](https://erlang.org/doc/apps/wx/index.html).
 
 <a name="licence"></a>
 
@@ -147,25 +147,15 @@ These are the possibilities so far:
 
 ### How to use C++ exceptions with wxWidgets?
 
-wxWidgets library itself is unfortunately _not_ exception-safe (as its initial
-version predates, by far, the addition of the exceptions to the C++ language).
-However you can still use the exceptions in your own code and use the other
-libraries using the exceptions for the error reporting together with wxWidgets.
+wxWidgets library itself is unfortunately _not_ exception-safe nor does it use
+exceptions itself (as its initial version predates, by far, the addition of the
+exceptions to the C++ language). However, you can still use the exceptions in your
+own code and use the other libraries using the exceptions for the error reporting
+together with wxWidgets.
 
-There are a few issues to keep in mind, though:
+See also description of `wxHandleFatalExceptions` function in the manual, where
+more information about exception handling in wxWidgets is provided.
 
-* You shouldn't let the exceptions propagate through wxWidgets code, in
-  particular you should always catch the exceptions thrown by the functions
-  called from an event handler in the handler itself and not let them propagate
-  upwards to wxWidgets.
-* You may need to ensure that the compiler support for the exceptions is
-  enabled as, considering that wxWidgets itself doesn't use the exceptions and
-  turning their support on results in the library size augmentation of 10% to
-  20%, it is turned off by default for a few compilers. Moreover, for gcc (or
-  at least its mingw version) you must also turn on the RTTI support to be able
-  to use the exceptions, so you should use the `--disable-no_rtti` and
-  `--disable-no_exceptions` options when configuring the library (note the
-  double negation).
 
 <a name="dev"></a>
 

--- a/docs/faq/general/index.md
+++ b/docs/faq/general/index.md
@@ -147,14 +147,11 @@ These are the possibilities so far:
 
 ### How to use C++ exceptions with wxWidgets?
 
-wxWidgets library itself is unfortunately _not_ exception-safe nor does it use
-exceptions itself (as its initial version predates, by far, the addition of the
-exceptions to the C++ language). However, you can still use the exceptions in your
-own code and use the other libraries using the exceptions for the error reporting
-together with wxWidgets.
-
-See also description of `wxHandleFatalExceptions` function in the manual, where
-more information about exception handling in wxWidgets is provided.
+wxWidgets library itself is _not_ exception-safe nor does it use exceptions
+(as its initial version predates, by far, the addition of the exceptions to the C++
+language). However, it is exception-friendly, please see
+[C++ Exceptions Overview](https://docs.wxwidgets.org/stable/overview_exceptions.html)
+for more information.
 
 
 <a name="dev"></a>

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -12,6 +12,7 @@ Welcome to the wxWidgets FAQ. Please select a category:
 * [Motif Specific Questions](/docs/faq/motif/)
 * [X11 Specific Questions](/docs/faq/x11/)
 
-For further information, please see the install.txt (per port), todo.txt (per
-port), and bugs.txt (all ports) files included with wxWidgets. The wxWiki also
-maintains [additional FAQs](https://wiki.wxwidgets.org/WxFAQ).
+For further information, please see the build and install instructions for the individual
+ports available in [Platform Details Overview](https://docs.wxwidgets.org/trunk/page_port.html).
+
+The wxWiki also maintains [additional FAQs](https://wiki.wxwidgets.org/WxFAQ).

--- a/docs/faq/windows/index.md
+++ b/docs/faq/windows/index.md
@@ -17,7 +17,6 @@ See also [top-level FAQ page](/docs/faq/).
 *   [Why are menu hotkeys or shortcuts not working in my application?](#shortcutproblem)
 *   [Is MS Active Accessibility supported?](#access)
 *   [Visual C++ gives errors about multiply defined symbols, what can I do?](#crtmismatch)
-*   [Why do I get compilation errors when using wxWidgets with DirectShow?](#directx)
 *   [How to get `HWND` of a wxWindow object?](#gethwnd)
 *   [How do I handle Windows messages in my wxWidgets program?](#handlewm)
 
@@ -150,24 +149,6 @@ you may also use the non MT-safe version as it is slightly smaller and faster.
 But the most important thing is to use the **same** CRT setting for all
 components of your project.
 
-<a name="directx"></a>
-
-### Why do I get compilation errors when using wxWidgets with DirectShow?
-
-If you get errors when including Microsoft DirectShow or DirectDraw headers,
-the following message from Peter Whaite could help:
-
-    > This causes compilation errors within DirectShow:
-    >
-    > wxutil.h(125) : error C2065: 'EXECUTE_ASSERT' : undeclared identifier
-    > amfilter.h(1099) : error C2065: 'ASSERT' : undeclared identifier
-
-    The reason for this is that __WXDEBUG__ is also used by the DXSDK (9.0
-    in my case) to '#pragma once' the contents of
-    DXSDK/Samples/C++/DirectShow/BaseClasses/wxdebug.h.  So if __WXDEBUG__
-    is defined, then wxdebug.h doesn't get included, and the assert macros
-    don't get defined.  You have to #undef __WXDEBUG__ before including the
-    directshow baseclass's `<streams.h>`.
 
 <a name="gethwnd"></a>
 

--- a/docs/faq/windows/index.md
+++ b/docs/faq/windows/index.md
@@ -7,22 +7,15 @@ See also [top-level FAQ page](/docs/faq/).
 ### List of questions in this category
 
 *   [Which Windows platforms are supported?](#platforms)
-*   [What do I need to do for Windows XP?](#winxp)
+*   [Why do controls in my application look odd?](#manifest)
+*   [Why does my application look blurry?](#hidpi)
 *   [What compilers are supported?](#compilers)
-*   [Which is the best compiler to use with wxWidgets?](#bestcompiler)
-*   [Is Unicode supported?](#unicode)
-*   [Does wxWidgets support double byte fonts (Chinese/Japanese/Korean etc.)?](#doublebyte)
-*   [Can you compile wxWidgets as a DLL?](#dll)
-*   [How can I reduce executable size?](#exesize)
 *   [Is wxWidgets compatible with MFC?](#mfc)
 *   [Why do I get errors about setup.h not being found?](#setuph)
 *   [Why do I get errors about FooBarA when I only use FooBar in my program?](#asuffix)
-*   [Why my code fails to compile with strange errors about new operator?](#newerrors)
 *   [How do I port MFC applications to wxWidgets?](#mfcport)
 *   [Why are menu hotkeys or shortcuts not working in my application?](#shortcutproblem)
-*   [Why can I not write to the HKLM part of the registry with wxRegConfig?](#regconfig)
 *   [Is MS Active Accessibility supported?](#access)
-*   [Why does Visual C++ complain about corrupted project files?](#dspfmt)
 *   [Visual C++ gives errors about multiply defined symbols, what can I do?](#crtmismatch)
 *   [Why do I get compilation errors when using wxWidgets with DirectShow?](#directx)
 *   [How to get `HWND` of a wxWindow object?](#gethwnd)
@@ -35,12 +28,24 @@ See also [top-level FAQ page](/docs/faq/).
 wxWidgets can be used to develop and deliver applications on Windows
 XP, Vista, 7, 8, 10.
 
-<a name="winxp"></a>
+<a name="manifest"></a>
 
-### What do I need to do for Windows XP?
+### Why do controls in my application look odd?
 
-The XP manifest is included in wx/msw/wx.rc and so your application will be
-themed automatically so long as you include wx.rc in your own .rc file.
+If the controls do not look as expected (very noticeable e.g. with buttons),
+your application probably does not have an [application manifest](https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests)
+and so Windows displays the controls unthemed, as if in Windows 9x.
+wxWidgets provides such a manifest in wx/msw/wx.rc and so your application will be
+themed automatically so long as you include that file in your own .rc file.
+
+<a name="hidpi"></a>
+
+### Why does my application look blurry?
+The most likely reason is that you have a High DPI display
+but your application does not state High DPI support.
+Please see [High DPI Support in wxWidgets Overview](https://docs.wxwidgets.org/trunk/overview_high_dpi.html).
+If you need more information about High DPI on Windows, 
+please read [Microsoft Windows High DPI Guide](https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows).
 
 <a name="compilers"></a>
 
@@ -49,83 +54,6 @@ themed automatically so long as you include wx.rc in your own .rc file.
 Please see [docs/msw/install.md](https://github.com/wxWidgets/wxWidgets/blob/master/docs/msw/install.md) file for up-to-date information.
 Also see [this article](https://docs.wxwidgets.org/trunk/page_introduction.html#page_introduction_requirements).
 
-<a name="bestcompiler"></a>
-
-### Which is the best compiler to use with wxWidgets?
-
-It's partly a matter of taste, but some people prefer Visual C++ since the
-debugger is very good, it's very stable, the documentation is extensive, and it
-generates small executables. Since project files are plain text, it's easy for
-me to generate appropriate project files for wxWidgets samples.
-
-Among the free compilers the best choice seem to be mingw32 (port of gcc to
-Win32), with all its different flavours.
-
-You can't beat Cygwin's price (free), and you can debug adequately using gdb.
-However, it's quite slow to compile since it does not use precompiled headers.
-
-Embarcadero C++ Builder is fine and allegedly very fast.
-
-<a name="unicode"></a>
-
-### Is Unicode supported?
-
-Yes, Unicode is fully supported.
-
-<a name="doublebyte"></a>
-
-### Does wxWidgets support double byte fonts (Chinese/Japanese/Korean etc.)?
-
-By far the best advice is to use Unicode build and avoid dealing with DBCS.
-Otherwise, for Japanese, it seems that wxWidgets has no problems working
-with double byte char sets (meaning DBCS, not Unicode). First you have to
-install Japanese support on your system and choose for ANSI translation
-`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Nls\CodePage=932` (default
-is 1252 for Western). Then you can see all the Japanese letters in wxWidgets
-applications.
-
-<a name="dll"></a>
-
-### Can you compile wxWidgets as a DLL?
-
-Yes, but be aware that distributing DLLs is a thorny issue and you may be
-better off compiling statically-linked applications, unless you're delivering
-a suite of separate programs, or you're compiling a lot of wxWidgets
-applications and have limited hard disk space.
-
-With a DLL approach, and with different versions and configurations of
-wxWidgets needing to be catered for, the end user may end up with a host of
-large DLLs in his or her Windows system directory, negating the point of using
-DLLs. Of course, this is not a problem just associated with wxWidgets!
-
-<a name="exesize"></a>
-
-### How can I reduce executable size?
-
-You can compile wxWidgets as a DLL (see above). You should also compile your
-programs for release using non-debugging and space-optimisation options.
-
-If you want to distribute really small executables, you can use
-[Petite](http://www.un4seen.com/petite/) by Ian Luck. This nifty utility
-compresses Windows executables by around 50%, so your 500KB executable will
-shrink to a mere 250KB. With this sort of size, there is reduced incentive to
-use DLLs. Another good compression tool (probably better than Petite) is
-[UPX](http://upx.sourceforge.net/).
-
-Please do not be surprised if MinGW produces a statically-linked minimal
-executable of 1 MB. Firstly, gcc produces larger executables than some
-compilers. Secondly, this figure will include most of the overhead of
-wxWidgets, so as your application becomes more complex, the overhead becomes
-proportionally less significant. And thirdly, trading executable compactness
-for the enormous increase in productivity you get with wxWidgets is almost
-always well worth it.
-
-If you have a really large executable compiled with MinGW (for example 20MB)
-then you need to configure wxWidgets to compile without debugging information:
-see docs/msw/install.txt for details. You may find that using configure instead
-of makefile.g95 is easier, particularly since you can maintain debug and
-release versions of the library simultaneously, in different directories. Also,
-run 'strip' after linking to remove all traces of debug info.
 
 <a name="mfc"></a>
 
@@ -161,21 +89,6 @@ redefines many symbols to have such suffix (or `'W'` in the Unicode builds).
 The fix is to either not include `<windows.h>` at all or include
 `"wx/msw/winundef.h"` immediately after it.
 
-<a name="newerrors"></a>
-
-### Why my code fails to compile with strange errors about new operator?
-
-The most common cause of this problem is the memory debugging settings in
-`wx/msw/setup.h`. You have a couple choices:
-
-1. Either disable overloading the global operator new completely by setting
-   wxUSE_GLOBAL_MEMORY_OPERATORS and wxUSE_DEBUG_NEW_ALWAYS to 0 in this file.
-2. Or leave them on but do #undef new after including any wxWidgets headers,
-   like this the memory debugging will be still on for wxWidgets sources but
-   off for your own code.
-
-Notice that IMHO the first solution is preferable for VC++ users who can use
-the VC++ CRT memory debugging features instead.
 
 <a name="mfcport"></a>
 
@@ -195,71 +108,15 @@ initial UI by looking at the behaviour of the MFC app, not its code.
 
 ### Why are menu hotkeys or shortcuts not working in my application?
 
-This can happen if you have a child window intercepting EVT_CHAR events and
-swallowing all keyboard input. You should ensure that event.Skip() is called
+This can happen if you have a child window intercepting `EVT_CHAR` events and
+swallowing all keyboard input. You should ensure that `event.Skip()` is called
 for all input that isn't used by the event handler.
 
 It can also happen if you append the submenu to the parent menu _before_ you
 have added your menu items. Do the append _after_ adding your items, or
 accelerators may not be registered properly.
 
-<a name="regconfig"></a>
 
-### Why can I not write to the HKLM part of the registry with wxRegConfig?
-
-Currently this is not possible because the wxConfig family of classes is
-supposed to deal with per-user application configuration data, and HKLM is only
-supposed to be writeable by a user with Administrator privileges. In theory,
-only installers should write to HKLM. This is still a point debated by the
-wxWidgets developers. There are at least two ways to work around it if you
-really need to write to HKLM.
-
-First, you can use wxRegKey directly, for example:
-
-```cpp
-wxRegKey regKey;
-
-wxString idName(wxT("HKEY_LOCAL_MACHINE\\SOFTWARE\\My Company\\My Product\\Stuff\\"));
-idName += packid;
-
-regKey.SetName(idName);
-
-{
-    wxLogNull dummy;
-    if (!regKey.Create())
-    {
-        idName = wxT("HKEY_CURRENT_USER\\SOFTWARE\\My Company\\My Product\\Stuff\\");
-        idName += packid;
-        regKey.SetName(idName);
-        if (!regKey.Create())
-            return FALSE;
-    }
-}
-
-if (!regKey.SetValue(wxT("THING"), (long) thing)) err += 1;
-
-regKey.Close();
-```
-
-Or, you can employ this trick suggested by Istvan Kovacs:
-
-```cpp
-class myGlobalConfig : public wxConfig
-{
-    myGlobalConfig() :
-        wxConfig ("myApp", "myCompany", "", "", wxCONFIG_USE_GLOBAL_FILE) {};
-    bool Write(const wxString& key, const wxString& value);
-}
-
-bool myGlobalConfig::Write (const wxString& key, const wxString& value)
-{
-    wxString path = wxString ("SOFTWARE\\myCompany\\myApp\\") + wxPathOnly(key);
-    wxString new_path = path.Replace ("/", "\\", true);
-    wxString new_key = wxFileNameFromPath (key);
-    LocalKey().SetName (wxRegKey::HKLM, path);
-    return wxConfig::Write (new_key, value);
-}
-```
 
 <a name="access"></a>
 
@@ -267,19 +124,6 @@ bool myGlobalConfig::Write (const wxString& key, const wxString& value)
 
 Please see [this page](/docs/tutorials/accessibility/) for the current status.
 
-<a name="dspfmt"></a>
-
-### Why does Visual C++ complain about corrupted project files?
-
-If you have downloaded the wxWidgets sources from the svn using a Unix svn
-client or downloaded a daily snapshot in `.tar.gz` format, it is likely that
-the project files have Unix line endings (LF) instead of the DOS ones (CR LF).
-However some old versions of Visual C++ can only open the
-files with the DOS line endings, so you must transform the files to this format
-using any of the thousands ways to do it.
-
-Of course, another possibility is to always use only the Windows svn client and
-to avoid this problem completely.
 
 <a name="crtmismatch"></a>
 


### PR DESCRIPTION
I believe that technical documentation should among else have its signal-to-noise ratio as high as possible. This is why I opted to cut out all the information I found not relevant (any more). My changes may seem too radical and I will understand if they are rejected.

But just few examples to (pre)defend myself:
1. Java and .NET are no longer biggest threats to wxWidgets future, hence they do not need to be mentioned.
2. I think that Unicode support is a given so there is no need to answer if it is supported. Similarly, I think it's the best if we forget about DBCS.
3. The "best compiler" section is outdated without mentioning there is a "free" MSVC compiler now as well clang.
4. We do not need to discuss whether it is possible to "compile wxWidgets as a DLL" nor how to reduce executable size.
5. I consider the section about errors with new operator obsolete, as those two defines are now always set to 0.

### Some remaining questions
**General FAQ**
_What is wxWidgets?_ Perhaps mention also at least wxLua and perhaps even wxErlang. I can see that they are both actively maintained; however, I have no knowledge of how usable they are in practice.

_How to use C++ exceptions with wxWidgets?_  Not sure if the text in the second bullet about having to turn exceptions on is still relevant.

**Windows FAQ**
_Why do I get compilation errors when using wxWidgets with DirectShow?_ I have never used DirectX but I suspect this may no longer be relevant and should be removed. However, I am not sure so perhaps somebody else knows?


