### PR TITLE
Migrate IRC channel to Libera Chat

### DIFF
--- a/_posts/2021-05-31-irc-channel-moving-to-libera-chat.md
+++ b/_posts/2021-05-31-irc-channel-moving-to-libera-chat.md
@@ -1,0 +1,34 @@
+---
+title: "IRC Channel Moving to Libera.Chat"
+date: 2021-05-31
+comments: true
+---
+
+As many of you might have heard, the Freenode IRC network changed management a
+week ago, in what can only be described as a hostile takeover. The original
+Freenode staff that has taken great care of us for about two decades now have
+all resigned from Freenode, and created [Libera.Chat][libera], which we have
+decided to migrate to. This decision aligns with hundreds other open source
+projects making the same migration now, including [Ubuntu][1], [Gentoo][2],
+[Wikimedia][3], [FreeBSD][4], [Fedora][5], [Arch Linux][6], [LibreELEC][7],
+[Arduino][8], and [PostgreSQL][9]. We understand that this may be disruptive,
+but believe this move will ultimately be best for everyone.
+
+In order to ensure that our relatively small IRC community of users isn't
+divided long term, we have muted our channel on Freenode, leaving a notice with
+updated instructions for joining our new channel on Libera.Chat, where you will
+find all of the same helpful and experienced wxWidgets users.
+
+Please see our [IRC Channel][irc] page for help with connecting to Libera.Chat.
+
+[libera]: https://libera.chat/
+[1]: https://lists.ubuntu.com/archives/ubuntu-irc/2021-May/001927.html
+[2]: https://www.gentoo.org/news/2021/05/23/Moving-to-Libera.html
+[3]: https://lists.wikimedia.org/hyperkitty/list/mediawiki-l@lists.wikimedia.org/thread/5VVH5LTZUIN63WNAJZFREMD66LFQLTFT/
+[4]: https://wiki.freebsd.org/IRC/Official-FreeBSD-IRC-channels-now-on-Libera-Chat
+[5]: https://communityblog.fedoraproject.org/irc-announcement/
+[6]: https://archlinux.org/news/move-of-official-irc-channels-to-liberachat/
+[7]: https://libreelec.tv/2021/05/freenode-news/
+[8]: https://forum.arduino.cc/t/arduino-irc-channel-moved-to-libera-chat/866788
+[9]: https://www.postgresql.org/about/news/migration-of-postgresql-irc-channels-2216/
+[irc]: /support/irc/

--- a/support/irc/index.md
+++ b/support/irc/index.md
@@ -3,18 +3,18 @@ title: "IRC Channel"
 ---
 
 If the documentation isn't enough and you need in-person help, you can try the
-`#wxwidgets` channel on the [Freenode][1] IRC server (`irc.freenode.net`). This
+`#wxwidgets` channel on the [Libera][1] IRC server (`irc.libera.chat`). This
 channel is regularly filled with many people who are all very experienced with
 wxWidgets and are often willing to help.
 
-[1]: https://freenode.net/
+[1]: https://libera.chat/
 
 <div class="row my-4 justify-content-center">
   <div class="col-md-6">
-    <a href="https://webchat.freenode.net/?channels=%23wxwidgets&amp;uio=OT10cnVlJjExPTIxNQ6c" target="_new" class="btn btn-lg btn-outline-primary btn-block">
+    <a href="https://web.libera.chat/#wxwidgets" target="_new" class="btn btn-lg btn-outline-primary btn-block">
       <i class="fas fa-globe fa-fw"></i> Launch Web Client
     </a>
-    <a href="irc://irc.freenode.net/wxwidgets" class="btn btn-lg btn-outline-primary btn-block">
+    <a href="irc://irc.libera.chat/wxwidgets" class="btn btn-lg btn-outline-primary btn-block">
       <i class="fas fa-desktop fa-fw"></i> Launch Desktop Client
     </a>
   </div>


### PR DESCRIPTION
- Updated the IRC support page, replacing Freenode with Libera Chat.
- Authored a news post announcing the move.