### PR TITLE
Update TravisCI information

### DIFF
--- a/develop/index.md
+++ b/develop/index.md
@@ -40,15 +40,11 @@ title: "Developers"
   <div class="col-sm-6">
     <h3>Continuous Integration</h3>
     <p>
-      wxWidgets employs AppVeyor, Travis CI and GitHub Actions
-      to run automated builds and tests:
+      wxWidgets employs AppVeyor and GitHub Actions to run automated builds and tests:
     </p>
     <p>
       <a href="https://ci.appveyor.com/project/wxWidgets/wxwidgets" target="_new">
         <img alt="AppVeyor Build Status" src="https://img.shields.io/appveyor/build/wxWidgets/wxWidgets?label=AppVeyor&logo=appveyor" />
-      </a>
-      <a href="https://travis-ci.org/wxWidgets/wxWidgets" target="_new">
-        <img alt="Travis CI Build Status" src="https://img.shields.io/travis/wxWidgets/wxWidgets?label=TravisCI&logo=travis" />
       </a>
       <a href="https://github.com/wxWidgets/wxWidgets/actions" target="_new">
         <img alt="GitHub Actions Status" src="https://img.shields.io/github/checks-status/wxWidgets/wxWidgets/master?label=GitHub&logo=github" />

--- a/thanks/index.md
+++ b/thanks/index.md
@@ -11,7 +11,7 @@ Many companies and individuals make significant contributions of infrastructure,
 The wxWidgets project receives support through the donation of infrastructure from the companies listed below. 
 
 
-### Infrastructure Sponsors
+### Current Infrastructure Sponsors
 
 {::options parse_block_html="true" /}
 
@@ -25,9 +25,6 @@ The wxWidgets project receives support through the donation of infrastructure fr
 </div>
 <div class="row">
   <div class="col-sm-6 my-auto">
-[![TravisLogo]][Travis]
-  </div>
-  <div class="col-sm-6 my-auto">
 <h2 class="display-4">[AppVeyor][AppVeyor]{: class="text-reset"}</h2>
   </div>
 </div>
@@ -40,11 +37,21 @@ The wxWidgets project receives support through the donation of infrastructure fr
 [MacStadiumLogo]: MacStadium-developerlogo.png 
 {: width="200px"}
 
-[Travis]: https://www.travis-ci.org
+[AppVeyor]: https://www.appveyor.com
+
+### Former Infrastructure Sponsors
+
+{::options parse_block_html="true" /}
+
+<div class="row">
+  <div class="col-sm-6 my-auto">
+[![TravisLogo]][Travis]
+  </div>
+</div>
+
+[Travis]: https://www.travis-ci.com
 [TravisLogo]: TravisCI-Full-Color.png 
 {: width="214px"}
-
-[AppVeyor]: https://www.appveyor.com
 
 ### Software and Financial Donations
 


### PR DESCRIPTION
I have removed Travis CI mention from the Developers page.

In the Thanks page, I have split the _Infrastructure Sponsors_ section into _Current Infrastructure Sponsors_ and _Former Infrastructure Sponsors_ and moved Travis CI into the latter.

I do not really understand the markup nor do I have a possibility to view it as HTML, so the changes in the Thanks page were made blindly and need to be checked.