### PR TITLE
Run "publish" workflow under Ubuntu 20.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       WX_SITE_DIR: ${{ github.workspace }}
     steps:


### PR DESCRIPTION
This might fix problems with compiling node-sass that prevent the
workflow from working under Ubuntu 18.04 any longer.