### PR TITLE
Add a page explaining wxTrac to GitHub Issues migration

### DIFF
--- a/develop/how-to-report-issues/trac-migration.md
+++ b/develop/how-to-report-issues/trac-migration.md
@@ -1,0 +1,31 @@
+---
+title: "wxTrac has been migrated to GitHub Issues"
+--- 
+
+wxWidgets project previously used [Trac][1] installation at
+`trac.wxwidgets.org`, known as wxTrac, for bug reporting, but since January
+2022 wxTrac is not used any longer and all new bugs should be reported on
+[GitHub][2]. Please see our [issue reporting guidelines][3] if you hadn't done
+this before.
+
+If you're looking for an existing bug report, you may find it at GitHub with
+the same ticket number as before, e.g. the ticket previously found at
+`http://trac.wxwidgets.org/ticket/12345` is now at
+`https://github.com/wxWidgets/wxWidgets/issues/12345`[^note]
+
+If you don't have and can't, or don't want to, open a GitHub account required
+to use GitHub Issues, or have any other questions about reporting issues in
+wxWidgets, please post them to [our mailing lists][4].
+
+[1]: https://trac.edgewall.org/
+[2]: https://github.com/wxWidgets/wxWidgets/issues/new/choose
+[3]: /develop/how-to-report-issues/
+[4]: https://www.wxwidgets.org/support/mailing-lists/
+
+---
+
+[^note]: This is not true for the very old tickets with numbers strictly less
+      than 2645 that are available as GitHub issues with numbers offset by
+      19365, i.e. the old Trac ticket #1 is at
+      `https://github.com/wxWidgets/wxWidgets/issues/19366`, if, for some
+      reason, you're still interested in them.


### PR DESCRIPTION
This page is not linked from the rest of the site, but will be used as a
landing page for the redirect from the old wxTrac URL.