### PR TITLE
Use git checkout instead of svn to get wx files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,13 @@ jobs:
     env:
       WX_SITE_DIR: ${{ github.workspace }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout Website
+        uses: actions/checkout@v3
+      - name: Checkout wxWidgets
+        uses: actions/checkout@v3
         with:
-          persist-credentials: 'false'
+          repository: wxWidgets/wxWidgets
+          path: wxWidgets
       - name: Yarn Install
         run: yarn
       - name: Compile Assets
@@ -40,8 +43,6 @@ jobs:
         run: ruby update_release_info.rb
       - name: Update Download Stats
         run: ruby _cron/update_download_stats.rb
-      - name: Download Locales
-        run: svn checkout https://github.com/wxWidgets/wxWidgets/trunk/locale/ _cron/locale
       - name: Update Translation Stats
         run: sudo apt install gettext && ./_cron/update_translation_stats.sh
       - name: Update wxXRC Schema

--- a/_cron/update_translation_stats.sh
+++ b/_cron/update_translation_stats.sh
@@ -8,7 +8,6 @@ CATALOGS_DIR="$WX_SITE_DIR/_cron/locale"
 STATUS_FILE="$WX_SITE_DIR/about/translations/stats.js"
 
 cd $CATALOGS_DIR
-svn update > /dev/null 2>&1
 
 echo 'processTranslationStats({' > $STATUS_FILE
 

--- a/_cron/update_translation_stats.sh
+++ b/_cron/update_translation_stats.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Set WX_SITE_DIR before running this script, and also run:
-# svn checkout https://github.com/wxWidgets/wxWidgets/trunk/locale/
+# This script relies on WX_SITE_DIR being set and wxWidgets sources
+# being available in its wxWidgets subdirectory.
 
 MSGFMT='msgfmt'
-CATALOGS_DIR="$WX_SITE_DIR/_cron/locale"
+CATALOGS_DIR="$WX_SITE_DIR/wxWidgets/locale"
 STATUS_FILE="$WX_SITE_DIR/about/translations/stats.js"
 
 cd $CATALOGS_DIR

--- a/_cron/update_wxxrc_schema.sh
+++ b/_cron/update_wxxrc_schema.sh
@@ -1,12 +1,11 @@
 #!/bin/sh
 
-# Set WX_SITE_DIR before running this script.
+# This script relies on WX_SITE_DIR being set and wxWidgets sources
+# being available in its wxWidgets subdirectory.
 
-SOURCE="https://raw.githubusercontent.com/wxWidgets/wxWidgets/master/misc/schema"
+SOURCE_DIR="$WX_SITE_DIR/wxWidgets/misc/schema"
 DESTINATION="$WX_SITE_DIR/schemas/"
 
 mkdir -p "$DESTINATION"
-cd "$DESTINATION"
-curl -O "$SOURCE/xrc_schema.rnc"
-curl -O "$SOURCE/xrc_schema_builtin_only.rnc"
+cp "$SOURCE_DIR/xrc_schema.rnc" "$SOURCE_DIR/xrc_schema_builtin_only.rnc" "$DESTINATION"
 


### PR DESCRIPTION
Using svn doesn't seem to work any longer (the last few runs all have given an error for `svn co` step) and there is no reason to use it anyhow, so switch to Git.