### PR TITLE
Add another IDE Setup/Configuration tutorial

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -55,7 +55,7 @@ page on the community wiki.
 ## IDE Setup/Configuration
 
 <div class="list-group my-3">
-<li class="list-group-item">
+  <li class="list-group-item">
     <h5 class="mb-1">
       <a href="https://github.com/PBfordev/wxpbguide">
         Starting with wxWidgets using MinGW and Code::Blocks

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -39,6 +39,19 @@ page on the community wiki.
   </li>
   <li class="list-group-item">
     <h5 class="mb-1">
+      <a href="http://www.informit.com/articles/article.asp?p=606222&amp;rl=1">
+        Programming C++ GUIs with the wxWidgets Library
+      </a>
+    </h5>
+    <p class="mb-0">
+      The wxWidgets library makes programming GUIs incredibly easy, far easier
+      than with most platform APIs. Jeff Cogswell shows how this handy C++
+      library can shorten your programming time with powerful classes that are
+      simple to use. Written by Jeff Cogswell.
+    </p>
+  </li>
+  <li class="list-group-item">
+    <h5 class="mb-1">
       <a href="http://zetcode.com/gui/wxwidgets/">
         Intermediate wxWidgets Tutorial
       </a>
@@ -67,19 +80,6 @@ page on the community wiki.
       show how to build wxWidgets using MinGW with various parameters affecting
       the resulting build. It also describes in detail setting-up a wxWidgets
       project in popular IDE Code::Blocks.
-    </p>
-  </li>
-  <li class="list-group-item">
-    <h5 class="mb-1">
-      <a href="http://www.informit.com/articles/article.asp?p=606222&amp;rl=1">
-        Programming C++ GUIs with the wxWidgets Library
-      </a>
-    </h5>
-    <p class="mb-0">
-      The wxWidgets library makes programming GUIs incredibly easy, far easier
-      than with most platform APIs. Jeff Cogswell shows how this handy C++
-      library can shorten your programming time with powerful classes that are
-      simple to use. Written by Jeff Cogswell.
     </p>
   </li>
   <li class="list-group-item">

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -82,16 +82,6 @@ page on the community wiki.
       project in popular IDE Code::Blocks.
     </p>
   </li>
-  <li class="list-group-item">
-    <h5 class="mb-1">
-      <a href="http://www.litwindow.com/Knowhow/Intellisense/intellisense.html">
-        Intellisense and wxWidgets
-      </a>
-    </h5>
-    <p class="mb-0">
-      How to get MS Visual Studio Intellisense working with wxWidgets.
-    </p>
-  </li>
 </div>
 
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -55,6 +55,20 @@ page on the community wiki.
 ## IDE Setup/Configuration
 
 <div class="list-group my-3">
+<li class="list-group-item">
+    <h5 class="mb-1">
+      <a href="https://github.com/PBfordev/wxpbguide">
+        Starting with wxWidgets using MinGW and Code::Blocks
+      </a>
+    </h5>
+    <p class="mb-0">
+      The Microsoft Windows specific guide hopes to assist the readers with
+      decisions regarding which wxWidgets version and configuration to use and
+      show how to build wxWidgets using MinGW with various parameters affecting
+      the resulting build. It also describes in detail setting-up a wxWidgets
+      project in popular IDE Code::Blocks.
+    </p>
+  </li>
   <li class="list-group-item">
     <h5 class="mb-1">
       <a href="http://www.informit.com/articles/article.asp?p=606222&amp;rl=1">


### PR DESCRIPTION
I took a look at some other tutorials.

**Section IDE Setup/Configuration**
_Programming C++ GUIs with the wxWidgets Library_
Not only it is rather old (published in 2006), I think setup/configuration are not its main focus.

_Intellisense and wxWidgets_ 
The link does not work, moreover, I would expect Intellisense work out of the box these days.

**Section wxWidgets and Others**
_Using wxWidgets with OpenCV_ 
Looks rather obsolete. I think even my [wxOpenCVTest](https://github.com/PBfordev/wxopencvtest) could be more useful nowadays; however, it has just code.