### PR TITLE
Add ability to hide posts from home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ To create a fresh News post, you can run:
 ```
 
 This will create the post file, and fill in all necessary YAML front matter.
-Then simply write your post in Markdown after the `---` marker. By default, the
-script will enable comments on your post. If this isn't desired, find `comments`
-in the YAML front matter, and change it from `true` to `false`.
+Then simply write your post in Markdown after the `---` marker.
+
+By default, the script will enable comments on your post. If this isn't desired,
+find `comments` in the YAML front matter, and change it from `true` to `false`.
+
+Also by default, new posts will be promoted on the home page. If this isn't
+desired, add `promoted: false` in the YAML front matter.
 
 For the blog posts, just use `./new_blog` instead of `new_post`, otherwise the
 behaviour is exactly the same.

--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,7 @@ defaults:
       type: posts
     values:
       layout: post
+      promoted: true
 
 collections:
   blog:

--- a/_posts/2022-04-04-wxwidgets-3.1.6-released.md
+++ b/_posts/2022-04-04-wxwidgets-3.1.6-released.md
@@ -2,6 +2,7 @@
 title: "wxWidgets 3.1.6 Released"
 date: 2022-04-04
 comments: true
+promoted: false
 ---
 
 wxWidgets 3.1.6 release is now

--- a/index.html
+++ b/index.html
@@ -35,7 +35,8 @@ layout: home
 
 <h1>Latest News</h1>
 
-{% for post in site.posts limit:5 %}
+{% assign promoted_posts = site.posts | where: "promoted", true %}
+{% for post in promoted_posts limit:5 %}
   <h3><a href="{{ post.url }}">{{ post.title }}</a></h3>
 
   <p class="text-muted">Posted on <time datetime="{{ post.date | datetime | date_to_xmlschema }}"{% if updated %} data-updated="true"{% endif %}>{{ post.date | date: "%B %d, %Y" }}</time></p>


### PR DESCRIPTION
This adds a new "promoted" attribute to posts, which defaults to true. Explicitly adding "promoted: false" to a post will hide it from the home page.